### PR TITLE
Fix issue where Glob 7.x can't handle the leading ! in an exclude pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/jpillora/node-glob-all.git"
   },
   "dependencies": {
-    "glob": "^4.0.6",
+    "glob": "^7.0.5",
     "yargs": "~1.2.6"
   },
   "devDependencies": {


### PR DESCRIPTION
People have been asking for a version that includes Glob 7.x since that doesn't have the RegExp DoS vulnerability. See https://github.com/jpillora/node-glob-all/issues/12

However Glob has changed how it handles the leading ! in the exclude patterns, treating it as a literal part of the pattern, rather than ignoring it as it did before.

This PR explicitly handles the ! character and passes an include flag into the globbedOne function.  It could possibly be refactored more extensively, since the code in the File constructor which calculates whether it is an include or exclude pattern is no longer needed.

Let me know whether you'd like me to remove that too.