### PR TITLE
Github action for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Run tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - name: Run tests
+      run: |
+        npm ci
+        npm t


### PR DESCRIPTION
Automates running tests via Github action as requested in https://github.com/jpillora/node-glob-all/issues/25.

Runs tests on [pull request open, reopen and sync](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), as well as manually via the [Run workflow UI button](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)